### PR TITLE
Fix javadoc deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Execute Gradle build
-        run: ./gradlew build
+        run: ./gradlew build --scan
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
   deploy-docs:
     environment:
       name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
+      url: ${{ steps.docs.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: docs
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,15 +55,6 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: './build/docs/javadoc'
-
-  # Deployment job
-  deploy-docs:
-    environment:
-      name: github-pages
-      url: ${{ steps.docs.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: docs
-    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,16 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          path: 'build/docs/javadoc'
+          path: './build/docs/javadoc'
+
+  # Deployment job
+  deploy-docs:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: docs
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@main
-        if: github.ref_name == 'master'
+        uses: actions/deploy-pages@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
 
       - name: Execute Gradle build
-        run: ./gradlew build --scan
+        run: ./gradlew build
 
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,14 @@ jobs:
         uses: actions/upload-pages-artifact@v1
         with:
           path: './build/docs/javadoc'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: docs
+    steps:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,3 +66,4 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1
+        if: github.ref_name == 'master'

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ compileJava {
     targetCompatibility = '1.8'
 }
 
-
 application {
     mainClass = 'es/ull/mazesolver/gui/MainWindow'
 }


### PR DESCRIPTION
Failed [because](https://github.com/MazeSolver/MazeSolver/runs/7834211977?check_suite_focus=true):
```
Error: Request failed with status code 400
    at createError (/home/runner/work/_actions/actions/deploy-pages/main/webpack:/deploy-pages/node_modules/axios/lib/core/createError.js:16:1)
    at settle (/home/runner/work/_actions/actions/deploy-pages/main/webpack:/deploy-pages/node_modules/axios/lib/core/settle.js:17:1)
    at IncomingMessage.handleStreamEnd (/home/runner/work/_actions/actions/deploy-pages/main/webpack:/deploy-pages/node_modules/axios/lib/adapters/http.js:293:1)
    at IncomingMessage.emit (node:events:402:35)
    at endReadableNT (node:internal/streams/readable:1343:12)
    at processTicksAndRejections (node:internal/process/task_queues:83:21)
```